### PR TITLE
[temporal-server] Upgrade to v1.30.4

### DIFF
--- a/bbot/bbot.yml
+++ b/bbot/bbot.yml
@@ -6,6 +6,6 @@ deps:
    behavior: ignore_failed
 modules:
   nuclei:
-    version: 3.7.1
+    version: 3.8.0
   gowitness:
     chrome_path: /usr/bin/chromium

--- a/bbot/requirements.txt
+++ b/bbot/requirements.txt
@@ -10,4 +10,4 @@ uvicorn
 # static bbot version to avoid breaking changes
 # bbot==2.8.4
 # bbot @ git+https://github.com/ciso360ai/bbot
-bbot @ git+https://github.com/blacklanternsecurity/bbot@b4e471840d926abfe427b04b81f75e593a95ebcb #v3.0@9/4/2026
+bbot @ git+https://github.com/blacklanternsecurity/bbot@35342055bfbb647a4a071b8833d836eb41a2de30 #dev@2026-04-24

--- a/temporal-server/Dockerfile
+++ b/temporal-server/Dockerfile
@@ -1,14 +1,17 @@
 # Check: https://github.com/temporalio/temporal/releases
-ARG TEMPORAL_VERSION=1.29.3
+ARG TEMPORAL_VERSION=1.30.4
+ARG TEMPORAL_CLI=1.6.2
 
-# Temporal source for build metadata
-FROM temporalio/auto-setup:1.29.3 AS temporal-source
+# Temporal CLI image for downloading the CLI binary
+FROM temporalio/temporal:${TEMPORAL_VERSION} AS temporal-cli
+FROM temporalio/admin-tools:${TEMPORAL_VERSION} AS temporal-admin-tools
 
 # Base image
 FROM alpine:3.23
 
 # Re-declare ARGs after FROM to make them available in this stage
 ARG TEMPORAL_VERSION
+ARG TEMPORAL_CLI
 ARG TARGETPLATFORM
 
 LABEL \
@@ -35,26 +38,32 @@ WORKDIR /etc/temporal
 # Download and install specific AMD64 versions
 RUN \
   if [ "$TARGETPLATFORM" = 'linux/amd64' ]; then \
+    mkdir -p /tmp/temporal && cd /tmp/temporal && \
     wget https://github.com/temporalio/temporal/releases/download/v${TEMPORAL_VERSION}/temporal_${TEMPORAL_VERSION}_linux_amd64.tar.gz \
+    && wget https://github.com/temporalio/cli/releases/download/v${TEMPORAL_CLI}/temporal_cli_${TEMPORAL_CLI}_linux_amd64.tar.gz \
     && tar -xzf temporal_${TEMPORAL_VERSION}_linux_amd64.tar.gz \
-    && mv temporal-* /usr/local/bin \
-    && rm -rf temporal-* \
-    && rm -rf *.tar.gz \
+    && tar -xzf temporal_cli_${TEMPORAL_CLI}_linux_amd64.tar.gz \
+    && mv temporal temporal-server temporal-sql-tool /usr/local/bin \
+    && rm -rf /tmp/temporal \
   ; fi
 
 # Download and install specific ARM64 versions
 RUN \
   if [ "$TARGETPLATFORM" = 'linux/arm64' ]; then \
+    mkdir -p /tmp/temporal && cd /tmp/temporal && \
     wget https://github.com/temporalio/temporal/releases/download/v${TEMPORAL_VERSION}/temporal_${TEMPORAL_VERSION}_linux_arm64.tar.gz \
+    && wget https://github.com/temporalio/cli/releases/download/v${TEMPORAL_CLI}/temporal_cli_${TEMPORAL_CLI}_linux_arm64.tar.gz \
     && tar -xzf temporal_${TEMPORAL_VERSION}_linux_arm64.tar.gz \
-    && mv temporal-* /usr/local/bin \
-    && rm -rf temporal-* \
-    && rm -rf *.tar.gz \
+    && tar -xzf temporal_cli_${TEMPORAL_CLI}_linux_arm64.tar.gz \
+    && mv temporal temporal-server temporal-sql-tool /usr/local/bin \
+    && rm -rf /tmp/temporal \
   ; fi
 
-COPY --from=temporal-source /etc/temporal/schema /etc/temporal/schema
-COPY --from=temporal-source /usr/local/bin/temporal /usr/local/bin/temporal
+# Copy SQL schema migrations needed by temporal-sql-tool at startup
+COPY --from=temporal-admin-tools /etc/temporal/schema /etc/temporal/schema
+
 COPY docker.yaml /etc/temporal/config/docker.yaml
+COPY dynamic_config.yaml /etc/temporal/config/dynamic_config.yaml
 COPY entrypoint.sh /etc/temporal/entrypoint.sh
 
 # Create user and directories

--- a/temporal-server/Dockerfile
+++ b/temporal-server/Dockerfile
@@ -2,8 +2,7 @@
 ARG TEMPORAL_VERSION=1.30.4
 ARG TEMPORAL_CLI=1.6.2
 
-# Temporal CLI image for downloading the CLI binary
-FROM temporalio/temporal:${TEMPORAL_VERSION} AS temporal-cli
+# SQL schema migrations source (temporal-sql-tool at startup)
 FROM temporalio/admin-tools:${TEMPORAL_VERSION} AS temporal-admin-tools
 
 # Base image

--- a/temporal-server/docker.yaml
+++ b/temporal-server/docker.yaml
@@ -168,5 +168,5 @@ namespaceDefaults:
 
 
 dynamicConfigClient:
-    filepath: "/temporal-data/dynamicconfig/docker.yaml"
+    filepath: "${DYNAMIC_CONFIG_FILE_PATH}"
     pollInterval: "60s"

--- a/temporal-server/dynamic_config.yaml
+++ b/temporal-server/dynamic_config.yaml
@@ -1,0 +1,6 @@
+# Temporal dynamic config overrides.
+# Format: each key maps to a list of constrained values.
+# Example:
+# frontend.rps:
+#   - value: 2000
+#     constraints: {}

--- a/temporal-server/entrypoint.sh
+++ b/temporal-server/entrypoint.sh
@@ -5,10 +5,8 @@ set -eu -o pipefail
 : "${BIND_ON_IP:=$(getent hosts "$(hostname)" | awk '{print $1;}')}"
 export BIND_ON_IP
 
-if [[ "${BIND_ON_IP}" == "0.0.0.0" || "${BIND_ON_IP}" == "::0" ]]; then
-    : "${TEMPORAL_BROADCAST_ADDRESS:=$(getent hosts "$(hostname)" | awk '{print $1;}')}"
-    export TEMPORAL_BROADCAST_ADDRESS
-fi
+: "${TEMPORAL_BROADCAST_ADDRESS:=$(getent hosts "$(hostname)" | awk '{print $1;}')}"
+export TEMPORAL_BROADCAST_ADDRESS
 
 # check TEMPORAL_ADDRESS is not empty
 if [[ -z "${TEMPORAL_ADDRESS:-}" ]]; then
@@ -60,7 +58,7 @@ fi
 : "${SERVICES:=history,matching,frontend,worker}"
 : "${LOG_LEVEL:=info}"
 : "${ENABLE_ES:=false}"
-: "${DYNAMIC_CONFIG_FILE_PATH:=/temporal-data/dynamicconfig/docker.yaml}"
+: "${DYNAMIC_CONFIG_FILE_PATH:=/etc/temporal/config/dynamic_config.yaml}"
 
 # Server setup
 : "${TEMPORAL_ADDRESS:=}"
@@ -227,9 +225,9 @@ setup_schema() {
 
 register_default_namespace() {
     echo "Registering default namespace: ${DEFAULT_NAMESPACE}."
-    if ! temporal operator namespace describe "${DEFAULT_NAMESPACE}"; then
+    if ! temporal operator namespace describe -n "${DEFAULT_NAMESPACE}"; then
         echo "Default namespace ${DEFAULT_NAMESPACE} not found. Creating..."
-        temporal operator namespace create --retention "${DEFAULT_NAMESPACE_RETENTION}" --description "Default namespace for Temporal Server." "${DEFAULT_NAMESPACE}"
+        temporal operator namespace create -n "${DEFAULT_NAMESPACE}" --retention "${DEFAULT_NAMESPACE_RETENTION}" --description "Default namespace for Temporal Server."
         echo "Default namespace ${DEFAULT_NAMESPACE} registration complete."
     else
         echo "Default namespace ${DEFAULT_NAMESPACE} already registered."
@@ -280,6 +278,11 @@ if [[ ${SKIP_SCHEMA_SETUP} != true ]]; then
     validate_db_env
     wait_for_db
     setup_schema
+else
+    # Even when skipping schema setup, wait for DB before starting the server.
+    # Temporal v1.30.4+ runs a schema version compatibility check at startup
+    # that requires a live DB connection.
+    wait_for_db
 fi
 
 # Run this func in parallel process. It will wait for server to start and then run required steps.

--- a/temporal-server/entrypoint.sh
+++ b/temporal-server/entrypoint.sh
@@ -282,6 +282,7 @@ else
     # Even when skipping schema setup, wait for DB before starting the server.
     # Temporal v1.30.4+ runs a schema version compatibility check at startup
     # that requires a live DB connection.
+    validate_db_env
     wait_for_db
 fi
 

--- a/temporal-ui/Dockerfile
+++ b/temporal-ui/Dockerfile
@@ -1,5 +1,5 @@
 # Check: https://github.com/temporalio/ui/releases
-FROM temporalio/ui:2.48.1
+FROM temporalio/ui:2.49.1
 
 LABEL \
     name="CISO360AI Temporal UI" \

--- a/zitadel/Dockerfile
+++ b/zitadel/Dockerfile
@@ -1,7 +1,7 @@
 # Custom Zitadel image with AWS RDS SSL support
 
 # Check: https://github.com/zitadel/zitadel/releases and use -debug variant for shell access
-FROM ghcr.io/zitadel/zitadel:v4.13.1-debug
+FROM ghcr.io/zitadel/zitadel:v4.14.0-debug
 
 LABEL \
     name="CISO360AI ZITADEL" \


### PR DESCRIPTION
## Summary

- Upgrade Temporal server from v1.29.3 → v1.30.4 (CLI v1.6.2), resolving all v1.30.4 breaking changes
- Minor dependency bumps: temporal-ui 2.49.1, zitadel v4.14.0, nuclei 3.8.0, bbot dev pin

## Breaking changes fixed (v1.30.4)

- **ARM64 build 404** — `TEMPORAL_CLI` ARG was silently empty in Alpine stage due to Docker ARG scoping; re-declared after `FROM alpine`
- **Dynamic config parse error** — `dynamicConfigClient.filepath` pointed back at the main server config; separated into a new `dynamic_config.yaml` and made path configurable via `DYNAMIC_CONFIG_FILE_PATH`
- **DB connection at startup** — v1.30.4 runs a schema version check unconditionally; `wait_for_db` now called even when `SKIP_SCHEMA_SETUP=true`
- **Schema migrations missing** — switched from deprecated `temporalio/auto-setup` to `temporalio/admin-tools` as schema source; explicitly copies `temporal-sql-tool`
- **broadcastAddress required** — v1.30.4 requires `broadcastAddress` unconditionally when services bind on all interfaces; now always derived from container hostname
- **Namespace CLI deprecation** — `temporal operator namespace describe/create` updated to use `-n` flag (positional arg deprecated in v1.30.4)

## Test plan

- [ ] `docker buildx build --platform linux/amd64,linux/arm64 images/temporal-server` builds cleanly
- [ ] `docker-compose up temporal` starts without errors
- [ ] Temporal UI reachable at `http://localhost:8081` and shows healthy cluster
- [ ] Workers connect and `default` namespace is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)