### PR TITLE
[temporal-server] Fix build — bump to 1.31.0 (1.30.4.1 has no binary assets)

### DIFF
--- a/temporal-server/Dockerfile
+++ b/temporal-server/Dockerfile
@@ -1,5 +1,5 @@
 # Check: https://github.com/temporalio/temporal/releases
-ARG TEMPORAL_VERSION=1.30.4.1
+ARG TEMPORAL_VERSION=1.31.0
 ARG TEMPORAL_CLI=1.6.2
 
 # SQL schema migrations source (temporal-sql-tool at startup)


### PR DESCRIPTION
## Summary

PR #54 pinned `TEMPORAL_VERSION` to `1.30.4.1`, which **broke the multi-arch build**:

```
wget .../v1.30.4.1/temporal_1.30.4.1_linux_amd64.tar.gz
wget: server returned error: HTTP/1.1 404 Not Found
```

`v1.30.4.1` is a Docker-image-only patch release (notes: "Update dependencies in v1.30.x branch" + "Update alpine to v3.23.4"). It re-cut Temporal's published Docker images but published **no `temporal_*.tar.gz` binary assets**. `temporal-server/Dockerfile` downloads those binary tarballs from GitHub releases, so the version must be one that ships them.

This bumps `TEMPORAL_VERSION` to **`1.31.0`** — the latest release, which has the binary tarball assets and the `temporalio/admin-tools:1.31.0` image. One-line ARG change; no config changes needed (v1.31.0's new features — Worker Controller, Principal Attribution, SQL `passwordCommand` — are all opt-in dynamic-config keys).

## ⚠️ Deployment note — DB schema upgrade required

`v1.31.0` requires a schema upgrade **before the server will start**:

- PostgreSQL **core** schema `v1.19` (adds `current_chasm_executions` table)
- PostgreSQL **visibility** schema `v1.14` (adds `TemporalExternalPayload*` columns)

The v1.31.0 server runs a schema-version compatibility check at startup and refuses to boot against an older schema. This image bundles the migrations and applies them via `temporal-sql-tool update-schema` **only when `SKIP_SCHEMA_SETUP=false`** (default is `true`). Before rolling out the v1.31.0 image, run the schema migration against the RDS instance.

## Test plan

- [ ] `docker buildx build --platform linux/amd64,linux/arm64` for `temporal-server` — confirm the `temporal_1.31.0_linux_*.tar.gz` download + extraction and the `admin-tools:1.31.0` schema `COPY --from` succeed.
- [ ] Verify the v1.31.0 server starts against an RDS instance with the upgraded schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)