### PR TITLE
[temporal-server] Fix PG-TLS — caFile not certFile (Temporal v1.31.0)

### DIFF
--- a/temporal-server/Dockerfile
+++ b/temporal-server/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
     mkdir -p /etc/temporal
 
 # Set environment variables for AWS RDS Postgres SSL
-ENV POSTGRES_TLS_CERT_FILE=/usr/local/share/ca-certificates/ca.crt
+ENV POSTGRES_TLS_CA_FILE=/usr/local/share/ca-certificates/ca.crt
 ENV AWS_CA_FILE=/usr/local/share/ca-certificates/ca.crt
 
 WORKDIR /etc/temporal

--- a/temporal-server/docker.yaml
+++ b/temporal-server/docker.yaml
@@ -20,11 +20,11 @@ persistence:
                 maxConnLifetime: 1h
                 tls:
                     enabled: ${POSTGRES_TLS_ENABLED}
-                    caFile: 
-                    certFile: ${POSTGRES_TLS_CERT_FILE}
-                    keyFile: 
+                    caFile: ${POSTGRES_TLS_CA_FILE}
+                    certFile:
+                    keyFile:
                     enableHostVerification: ${SQL_HOST_VERIFICATION}
-                    serverName: 
+                    serverName:
         visibility:
             sql:
                 pluginName: ${DB}
@@ -38,11 +38,11 @@ persistence:
                 maxConnLifetime: 1h
                 tls:
                     enabled: ${POSTGRES_TLS_ENABLED}
-                    caFile: 
-                    certFile: ${POSTGRES_TLS_CERT_FILE}
-                    keyFile: 
+                    caFile: ${POSTGRES_TLS_CA_FILE}
+                    certFile:
+                    keyFile:
                     enableHostVerification: ${SQL_HOST_VERIFICATION}
-                    serverName: 
+                    serverName:
 
 global:
     membership:


### PR DESCRIPTION
## Summary

- Temporal **v1.31.0** tightened DSN validation in `common/persistence/sql/sqlplugin/db_handle.go`: `tls.certFile` set without `tls.keyFile` is now a **hard failure** (silently tolerated in v1.30.4).
- `sst deploy` of [ciso360ai/ciso360ai PR #526](https://github.com/ciso360ai/ciso360ai/pull/526) (the v0.8.7 image roll-out) hit it:
  ```
  ERROR sql handle: unable to refresh database connection pool
        {"error": "...TLS certFile is set but TLS keyFile is not set..."}
  ```
- **Root cause** — wrong-field bug latent since v0.8.0: the [RDS `global-bundle.pem`](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) downloaded in `temporal-server/Dockerfile` is a **server CA bundle** (verifies the RDS server's identity), so it belongs in `tls.caFile` — not `tls.certFile`, which is for **client mutual-TLS** (RDS does not use it). The Dockerfile baked `POSTGRES_TLS_CERT_FILE` as an `ENV` pointing at the CA bundle, and `docker.yaml` interpolated it into `certFile:` while leaving `caFile:` empty. v1.30.4 tolerated the mismatch; v1.31.0 does not.

## Fix

- `temporal-server/Dockerfile` — rename the baked `ENV` from `POSTGRES_TLS_CERT_FILE` to `POSTGRES_TLS_CA_FILE` (path unchanged).
- `temporal-server/docker.yaml` — both `default` and `visibility` datastore blocks: move `${POSTGRES_TLS_CA_FILE}` into `caFile:`; leave `certFile:` empty.
- `temporal-server/entrypoint.sh` — **no change**. Every `temporal-sql-tool` invocation already passes `--tls-ca-file "$POSTGRES_TLS_CA_FILE"` alongside `--tls-cert-file "$POSTGRES_TLS_CERT_FILE"`. After the rename, the CA path lands on the CA flag and the cert flag stays empty — exactly what v1.31.0's DSN builder accepts.

Total diff: **+9 / -9** across two files.

## Downstream

The consuming repo `ciso360ai/ciso360ai` (`infra/temporal.ts`) must also rename its env var from `POSTGRES_TLS_CERT_FILE` to `POSTGRES_TLS_CA_FILE`. That change ships on [PR #526](https://github.com/ciso360ai/ciso360ai/pull/526) as the `v0.8.7` → `v0.8.8` follow-up once this PR is merged + tagged as `v0.8.8`.

## Test plan

- [ ] `docker build -t test-ts:fix temporal-server/` succeeds.
- [ ] `docker run --rm test-ts:fix env | grep TLS` shows `POSTGRES_TLS_CA_FILE=…`, no `POSTGRES_TLS_CERT_FILE`.
- [ ] Render-check: `docker run --rm --entrypoint sh test-ts:fix -c 'envsubst < /etc/temporal/config/docker.yaml | grep -A6 tls'` shows `caFile: /usr/local/share/ca-certificates/ca.crt`, `certFile:` empty, `keyFile:` empty.
- [ ] End-to-end: `sst deploy` of `ciso360ai/ciso360ai` `updates-images-260522` branch with `temporal-server:0.8.8` succeeds; `temporal operator cluster health` returns OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)