### PR TITLE
[deps] exclude-newer 7d->3d + uv 0.11.24 + sync eligible bumps

### DIFF
--- a/backend-base/Dockerfile
+++ b/backend-base/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv from the official static-binary image (pinned)
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /usr/local/bin/
 
 # Copy lockfile + project metadata
 COPY pyproject.toml uv.lock .python-version ./

--- a/backend-base/pyproject.toml
+++ b/backend-base/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.0.0"
 description = "CISO360AI backend base image — runtime Python dependencies"
 requires-python = ">=3.14,<3.15"
 # Runtime dependencies only — no test frameworks (production base image).
-# Mirrors ciso360ai/ciso360ai backend/pyproject.toml runtime section.
 dependencies = [
     # Core web framework
     "fastapi",
@@ -52,5 +51,5 @@ dependencies = [
 
 [tool.uv]
 package = false
-# Supply-chain cooldown: ignore releases <7 days old (mirrors the main repo).
-exclude-newer = "7 days"
+# Supply-chain cooldown: ignore releases published in the last 3 days.
+exclude-newer = "3 days"

--- a/backend-base/uv.lock
+++ b/backend-base/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = "==3.14.*"
 
 [options]
-exclude-newer = "2026-06-12T19:52:25.254756595Z"
-exclude-newer-span = "P7D"
+exclude-newer = "2026-06-23T02:29:22.860011123Z"
+exclude-newer-span = "P3D"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -898,15 +898,15 @@ wheels = [
 
 [[package]]
 name = "stripe"
-version = "15.2.0"
+version = "15.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/28/c3550f39d9e258c21bcba81a89ef3ca7af352ad2cb14fe16b80248841644/stripe-15.2.0.tar.gz", hash = "sha256:f795d8a8ff27433e9ab03099afc0f5c4e992a8a6f92b9f839dc0048bb12f76f6", size = 1520207, upload-time = "2026-05-27T20:34:44.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/04/a41c498352317d0c3d52dfb265f3c3c3e50f1468fcacef5b6794dd57c967/stripe-15.2.1.tar.gz", hash = "sha256:5821a802abf70be900d7b1b6bb609697cc25c9aa521eb86430e68b994dac9f78", size = 1520402, upload-time = "2026-06-12T22:44:12.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/2b/697003ba6349058b65a5cb6b0bd8a8b0e909ed35911f7beebfc24b0563ee/stripe-15.2.0-py3-none-any.whl", hash = "sha256:e74d45bb07bb912fdc4ce81ffbdf184bcb92ce6e210cb7939966e537021c1842", size = 2168459, upload-time = "2026-05-27T20:34:42.312Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/be/b16d1222b8b47b5c1bf188523df679f28a9ff9662ad8276a02a56101463c/stripe-15.2.1-py3-none-any.whl", hash = "sha256:49571ffbfd7944daae4000e33d3b42705012ee7aae003b7b67868c1e59d442f5", size = 2168627, upload-time = "2026-06-12T22:44:10.458Z" },
 ]
 
 [[package]]

--- a/bbot/Dockerfile
+++ b/bbot/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /tmp
 
 # Install uv from the official static-binary image (pinned)
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /usr/local/bin/
 
 # Copy lockfile + project metadata
 COPY pyproject.toml uv.lock .python-version ./

--- a/bbot/pyproject.toml
+++ b/bbot/pyproject.toml
@@ -24,14 +24,15 @@ dependencies = [
     "urllib3>=2.7.0",
     "dnspython>=2.8.0",
     "pyjwt>=2.13.0",
-    "cryptography>=47.0.0",
+    # Held below the 49.0 major (backwards-incompatible); lift after validation.
+    "cryptography>=47.0.0,<49",
     "pyyaml>=6.0.3,<7.0",
 ]
 
 [tool.uv]
 package = false
-# Supply-chain cooldown: ignore releases <7 days old (mirrors the main repo).
-exclude-newer = "7 days"
+# Supply-chain cooldown: ignore releases published in the last 3 days.
+exclude-newer = "3 days"
 
 [tool.uv.sources]
 bbot = { git = "https://github.com/blacklanternsecurity/bbot", rev = "404bbbc2eaa5b6187580f4d9cd301da7a814aac7" }

--- a/bbot/uv.lock
+++ b/bbot/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = "==3.14.*"
 
 [options]
-exclude-newer = "2026-06-12T19:52:25.710172608Z"
-exclude-newer-span = "P7D"
+exclude-newer = "2026-06-23T02:27:19.839051487Z"
+exclude-newer-span = "P3D"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -397,7 +397,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
     { name = "bbot", git = "https://github.com/blacklanternsecurity/bbot?rev=404bbbc2eaa5b6187580f4d9cd301da7a814aac7" },
-    { name = "cryptography", specifier = ">=47.0.0" },
+    { name = "cryptography", specifier = ">=47.0.0,<49" },
     { name = "dnspython", specifier = ">=2.8.0" },
     { name = "fastapi" },
     { name = "httpx", extras = ["http2"] },

--- a/temporal-ui/Dockerfile
+++ b/temporal-ui/Dockerfile
@@ -1,5 +1,5 @@
 # Check: https://github.com/temporalio/ui/releases
-FROM temporalio/ui:2.51.0
+FROM temporalio/ui:2.51.1
 
 LABEL \
     name="CISO360AI Temporal UI" \

--- a/zitadel/Dockerfile
+++ b/zitadel/Dockerfile
@@ -1,7 +1,7 @@
 # Custom Zitadel image with AWS RDS SSL support
 
 # Check: https://github.com/zitadel/zitadel/releases and use -debug variant for shell access
-FROM ghcr.io/zitadel/zitadel:v4.15.1-debug
+FROM ghcr.io/zitadel/zitadel:v4.15.3-debug
 
 LABEL \
     name="CISO360AI ZITADEL" \


### PR DESCRIPTION
## Summary

Shortens the `uv` supply-chain cooldown (`[tool.uv] exclude-newer`) from **7 → 3 days** in both Python projects (`bbot/`, `backend-base/`) and folds in the dependency bumps that become eligible under the shorter window, plus toolchain/base-image refreshes.

- **Cooldown 7d → 3d** + lockfiles regenerated (`exclude-newer-span` P7D → P3D). The window change alone moves no package versions.
- **stripe 15.2.0 → 15.2.1** (`backend-base`) — eligible under the 3-day window (patch: user-agent `source` field).
- **cryptography held at 48.x** — capped `>=47.0.0,<49` in `bbot/pyproject.toml`. The 49.0 major is backwards-incompatible; kept aligned with the rest of the stack pending a coordinated bump.
- **uv 0.11.7 → 0.11.24** in both Dockerfiles. Install method unchanged (pinned distroless `COPY --from=ghcr.io/astral-sh/uv:<ver>`), which matches uv's documented best practice.
- **zitadel v4.15.1-debug → v4.15.3-debug** — latest; adds token-exchange client/scope validation + verified-email-before-auto-link fixes (supersedes the v4.15.2 Dependabot proposed).
- **temporal-ui 2.51.0 → 2.51.1**.
- Dropped main-repo references from the (public) pyproject comments.

## Verification

- `uv lock --check` passes for both projects; the only package move is stripe 15.2.1.
- `backend-base`, `bbot`, `zitadel`, `temporal-ui` images all build; `uv --version` → 0.11.24 in both Python images.

## Supersedes

- Dependabot stripe → 15.2.1 (folded in)
- Dependabot zitadel → v4.15.2-debug (superseded; this goes to v4.15.3-debug)
- Dependabot cryptography → 49.0.0 (held at 48.x via the `<49` cap)