### PR TITLE
[deps] Bump temporal 1.31.2, temporal-ui 2.52.0, zitadel 4.16.0, bbot + Python deps

### DIFF
--- a/backend-base/uv.lock
+++ b/backend-base/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.14.*"
 
 [options]
-exclude-newer = "2026-06-30T21:27:57.665966006Z"
+exclude-newer = "2026-07-08T22:18:22.754126432Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -413,7 +413,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -422,9 +422,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -932,7 +932,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.29.0"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -940,13 +940,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/95/22e2e19ad95d42d69320e8cd8d48c8543841f367d2d5a4dca48165e466d2/temporalio-1.29.0.tar.gz", hash = "sha256:3fbfddc5f847956ca20c2e671d3f09cefdb2ab6f0d6a6d59664c6102e922f80b", size = 2657001, upload-time = "2026-06-17T21:18:16.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/b0/ad8fc3cd7425c6551a637bf23c798e8fdd8eb7a3ec4fee4f46f7678ba8d2/temporalio-1.30.0.tar.gz", hash = "sha256:7c025919511bb465392d547e48ccb85fd560a995db4ebcc82fdb43cddf088e6f", size = 2686876, upload-time = "2026-07-02T21:04:46.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/82/e0810e7e7f5f4eb97e40468abf6bc8d3df0dbc882c09a2c207c38c90d56d/temporalio-1.29.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9d18f989fbea13014e3221de034fbd1945ec05499b663195f0eacb49cc922986", size = 14874156, upload-time = "2026-06-17T21:18:03.299Z" },
-    { url = "https://files.pythonhosted.org/packages/41/48/55a2f948f4cd30d8dcaf1d37a15e23b34d90a68d0d1da6765a08c650bbb2/temporalio-1.29.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:28bc12b64a7ffc08f7709897d3a0c93faa8972227734669f248cb7de2ce3e69f", size = 14384773, upload-time = "2026-06-17T21:18:06.151Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/71/a13f427089b54de4e11f347b2043934d693baffda569c4b4914e588a6074/temporalio-1.29.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd02a107c3f5fa088ed5e4aeda9af91d11afbc53dfd5b28d730776354b159297", size = 14602055, upload-time = "2026-06-17T21:18:08.704Z" },
-    { url = "https://files.pythonhosted.org/packages/73/6a/3ee32775c9b5172560add2ec69c554f476bc6c51ea7a3c24206e03f08cc5/temporalio-1.29.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:950b42e05793762eb7b4b3809e78c9e9dcdf2f23f797aa939ac17eca8ad9b3d3", size = 15075878, upload-time = "2026-06-17T21:18:11.499Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/92/24ef16052075a08e7ed071311704a244944485bc8581d82313f0c3d1b385/temporalio-1.29.0-cp310-abi3-win_amd64.whl", hash = "sha256:8969718f947c6b9df3b51ab4a71bad67abfce81a1023aa1a598a224b712b713a", size = 15333733, upload-time = "2026-06-17T21:18:14.201Z" },
+    { url = "https://files.pythonhosted.org/packages/02/39/842fdffe93388dd30ac12a53a698f71cbfb68b3bc938f30f3e5d6a36d4ad/temporalio-1.30.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6773a6b708dee7675fcbb681bf28e48337ce43b8467ceba8f903e78ae68909f8", size = 14520026, upload-time = "2026-07-02T21:04:31.384Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f3/a2237d5265eb29de591abeac7610a48616b590a1b923b4919f60ee81adfa/temporalio-1.30.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4038c3ce2d9acc12fef31dd16ef9be8cc7f721672da5662aa05e3942d0b5c9d1", size = 14018523, upload-time = "2026-07-02T21:04:34.405Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/57/dc648d812f4c688bd246a616f0d65c5f03b33675df2effb1b480e1df6d21/temporalio-1.30.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:108d1a56e174eabc18add58316084cdead230e239d3df22bbe999d6954986591", size = 14330502, upload-time = "2026-07-02T21:04:37.39Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e1/dbd57de0f5090891850c2ee5490319834a12b704076b11f32a4a149998d4/temporalio-1.30.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47b156138de30c2cd6723d5bfc06a30abcf680344c5481abb31f2a98a9b1f809", size = 14833364, upload-time = "2026-07-02T21:04:40.454Z" },
+    { url = "https://files.pythonhosted.org/packages/30/2a/6d41289c11465ba276a8b417f31d2e469f0fe4b8afacd61d5244151c5fce/temporalio-1.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:3adee28d5ec47bd6309a5eeef7b00126373f119bc5c1b058a34de098542f4da7", size = 15181893, upload-time = "2026-07-02T21:04:43.609Z" },
 ]
 
 [[package]]

--- a/bbot/Dockerfile
+++ b/bbot/Dockerfile
@@ -40,7 +40,7 @@ RUN uv sync --frozen --no-install-project
 RUN bbot --dry-run -t ciso360.net -p kitchen-sink \
     -c interactsh_disable=true \
     -em asn,skymem,myssl,medusa,git_clone,github_org,crt,crt_db,trufflehog \
-    -m ajaxpro,aspnet_bin_exposure,baddns,baddns_direct,baddns_zone,badsecrets,bucket_amazon,bucket_digitalocean,bucket_firebase,bucket_google,bucket_hetzner,bucket_microsoft,bypass403,dnscommonsrv,dotnetnuke,dnsbrute,dnsbrute_mutations,docker_pull,filedownload,fingerprintx,generic_ssrf,git,gitdumper,gitlab_com,gitlab_onprem,gowitness,graphql_introspection,host_header,http,hunt,iis_shortnames,jadx,legba,lightfuzz,newsletters,ntlm,nuclei,oauth,paramminer_cookies,paramminer_getparams,paramminer_headers,portscan,reflected_parameters,retirejs,robots,securitytxt,sslcert,telerik,url_manipulation,wafw00f,webbrute,webbrute_shortnames,wpscan,trajan \
+    -m ajaxpro,aspnet_bin_exposure,baddns,baddns_direct,baddns_zone,badsecrets,bucket_amazon,bucket_digitalocean,bucket_firebase,bucket_google,bucket_hetzner,bucket_microsoft,bypass403,dnscommonsrv,dotnetnuke,dnsbrute,dnsbrute_mutations,docker_pull,filedownload,fingerprintx,generic_ssrf,git,gitdumper,gitlab_com,gitlab_onprem,gowitness,graphql_introspection,host_header,http,hunt,iis_shortnames,jadx,legba,lightfuzz,newsletters,ntlm,nuclei,oauth,paramminer_cookies,paramminer_getparams,paramminer_headers,portscan,reflected_parameters,retirejs,robots,securitytxt,sslcert,telerik,url_manipulation,wafw00f,webbrute,webbrute_shortnames,trajan \
     && rm -rf /root/.cache/pip /root/.cache/gem /root/.cache/ansible
 
 CMD [ "bash" ]

--- a/bbot/bbot.yml
+++ b/bbot/bbot.yml
@@ -6,6 +6,6 @@ deps:
    behavior: ignore_failed
 modules:
   nuclei:
-    version: 3.9.0
+    version: 3.11.0
   gowitness:
     chrome_path: /usr/bin/chromium

--- a/bbot/pyproject.toml
+++ b/bbot/pyproject.toml
@@ -34,4 +34,4 @@ package = false
 exclude-newer = "3 days"
 
 [tool.uv.sources]
-bbot = { git = "https://github.com/blacklanternsecurity/bbot", rev = "404bbbc2eaa5b6187580f4d9cd301da7a814aac7" }
+bbot = { git = "https://github.com/blacklanternsecurity/bbot", rev = "69ec06adef33fa5c3d4cdee2c8d370ac892cceb0" }

--- a/bbot/uv.lock
+++ b/bbot/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.14.*"
 
 [options]
-exclude-newer = "2026-06-23T19:09:58.212464895Z"
+exclude-newer = "2026-07-08T22:26:32.396921803Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -148,17 +148,17 @@ wheels = [
 
 [[package]]
 name = "asndb"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "blasthttp" },
     { name = "cachetools" },
-    { name = "httpx" },
     { name = "radixtarget" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/2b/86f8d056d24476aeb0f7e63fb971b870f7018e728d9272a05232157cae30/asndb-1.0.4.tar.gz", hash = "sha256:23989a4a09e66b76a86b1a36eea78138b4a3001b5f909bb89e110635bb1723f2", size = 18956, upload-time = "2026-03-27T20:45:56.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/3a/e93d97e0455dbee83611bd3d61bc936e05ad361fcdb1131a1c4d257c6627/asndb-1.1.0.tar.gz", hash = "sha256:435a9741ea66d68b817c9c1054729f88c3d5eba94b96ca991b159ad40b23d0ca", size = 18987, upload-time = "2026-06-16T03:45:25.777Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/d7/a9084a90ea60919f84c39dc2302d802c9047b87373fcc2309898ca4095d9/asndb-1.0.4-py3-none-any.whl", hash = "sha256:a62e4f5872e12cbd4b146c7583f7bf2a5239e43ed20a63728295058ee3f1a3db", size = 18467, upload-time = "2026-03-27T20:45:57.022Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c4/89dafea4540b2590d1bd114438a6003abc3fd7047ea5eed02b0a0abf3d89/asndb-1.1.0-py3-none-any.whl", hash = "sha256:5cb47356014b20bbbca1114babc7cdc1227c5b81caf1638ab693e05f2a222b5f", size = 18509, upload-time = "2026-06-16T03:45:26.44Z" },
 ]
 
 [[package]]
@@ -172,8 +172,8 @@ wheels = [
 
 [[package]]
 name = "bbot"
-version = "3.0.0"
-source = { git = "https://github.com/blacklanternsecurity/bbot?rev=404bbbc2eaa5b6187580f4d9cd301da7a814aac7#404bbbc2eaa5b6187580f4d9cd301da7a814aac7" }
+version = "3.0.1"
+source = { git = "https://github.com/blacklanternsecurity/bbot?rev=69ec06adef33fa5c3d4cdee2c8d370ac892cceb0#69ec06adef33fa5c3d4cdee2c8d370ac892cceb0" }
 dependencies = [
     { name = "ansible-core" },
     { name = "ansible-runner" },
@@ -262,20 +262,20 @@ wheels = [
 
 [[package]]
 name = "blasthttp"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/cc/9840c1fd5aa0d71b9ec18702f4829c617a74543c819f845c2eb3e4b51b17/blasthttp-0.8.0.tar.gz", hash = "sha256:0b787e943ef0e779874802e854540a74bbdadc9729a4769ef0380e2005dc8a0e", size = 151255, upload-time = "2026-06-03T16:42:43.633Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/53/9d6b95be1a088c9910fbe66737321c9ecc2a276ca9bd8bb9a980ce95f78c/blasthttp-0.9.0.tar.gz", hash = "sha256:26ea06cbe41d06c54f32d0f44f863f352a1e25c3bb7708371e6a6a1f14f10887", size = 155052, upload-time = "2026-06-15T21:36:52.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/bf/a05d5c73d55cc165d0f5ab8c6dbac843547a06d5cab94456307530402897/blasthttp-0.8.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:340f85223bf6a5caf1b1337a6cd207e3ec9c891a68e2cf798ec3b2f792a99559", size = 4760019, upload-time = "2026-06-03T16:41:26.369Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/87/459221e7caac368f76ce722a91c773eac4b97fa06cb8d9b02aef3378d6ad/blasthttp-0.8.0-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:b4fed5b1fde40981a68c2e51388979820ca10c19d4e918ba14d30986775e1048", size = 4070310, upload-time = "2026-06-03T16:41:35.568Z" },
-    { url = "https://files.pythonhosted.org/packages/29/45/7936ef2a85849353a5dc6d3d30cdb09cf3b9a254a5b22f2b1071c8fd5888/blasthttp-0.8.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:3aef5de8af4e39fd0c48fcc6d1ed2e2d1ad4b6e08ec4adb731e65c201b4dd7a3", size = 4660407, upload-time = "2026-06-03T16:42:01.071Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/21/bea405147a9b5c25c428eed1a643bb75d13af340318fa8ad321ca90598ce/blasthttp-0.8.0-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:8f725cf3af1e29d19d8029a1cc7336a60275f8a7227816822ee1325468f72b4d", size = 4659076, upload-time = "2026-06-03T16:41:43.932Z" },
-    { url = "https://files.pythonhosted.org/packages/67/18/c232401bc881a771e460da3683fedb4bd151525bf8a6c28225e2bffa4b28/blasthttp-0.8.0-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:45c05d19fbc9691a4ebb6f3952da3bb29549a54f71921bf76e98aecc7cf69480", size = 4279493, upload-time = "2026-06-03T16:41:52.524Z" },
-    { url = "https://files.pythonhosted.org/packages/06/53/d50542f5bae28f2aa6cac9ee465c1ebc8e5030f5ce56ba33a19efd28e062/blasthttp-0.8.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d8bcc51940a721f9fe5a719649cc0a82d9cd1cda849c0bb8d8e30a9a85123430", size = 4413576, upload-time = "2026-06-03T16:42:09.102Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/86/33478451ff04a67a8cffd76d5ebe6520b89931fcb61d8ae0f3637c696350/blasthttp-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3e37825847337904bb0bdf0dc959833431aec3716200d7a23c057c4291755f1b", size = 5047184, upload-time = "2026-06-03T16:42:17.554Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/47/12b2246f310e062da827c523b50353ca303414dfff228855c6741d2b6043/blasthttp-0.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:04c77b2346ed3d5687c95f30815865ed54d4accbd53d4b972ad63f22f32e245e", size = 4375613, upload-time = "2026-06-03T16:42:25.868Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/d4/7374eb72e2e2a965fb1a8bd9034377021b64607682d096d7c4c95359f7bb/blasthttp-0.8.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2852f6386e8ed18b46d5e2f8ecf7e8dda16d708fe477176ee31a833990b8b1ed", size = 4791538, upload-time = "2026-06-03T16:42:34.156Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/3e/b053e3363d5bee4f2c0411a049718afbc39502db17ecee3cbefe1f73d78b/blasthttp-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45d544be8678c0425cd3f78261e5e986536dc5413424682958901d8210447daa", size = 4752925, upload-time = "2026-06-03T16:42:42.363Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a4/f799a142cd33bcb2121c097d4db5864328aef94b758735f50df4bb2f7b04/blasthttp-0.9.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:157d875d352dd362f0860d4c6538a21b1b74dbefe20fa98993d629db4f10c7c8", size = 4762944, upload-time = "2026-06-15T21:35:42.21Z" },
+    { url = "https://files.pythonhosted.org/packages/89/65/c65faeed8900a1da12e819789f2086624c01d78ad828d96ff29db7eafed1/blasthttp-0.9.0-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:75d8d8c056d717e2c1cbbd50fa60e02d7934418dec8c6c799b1d7536cefce250", size = 4075125, upload-time = "2026-06-15T21:35:49.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/29/2a1f85e3eb87af41039e43e8f7c4fe131e861ac74a68682a5991d3ba8dc4/blasthttp-0.9.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:f71338fe994e792e5be51798c265503fa22b27ebe8194aae3479451b67ff2e51", size = 4673382, upload-time = "2026-06-15T21:36:12.8Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/7e/259e9514f6bc686d7b9cba98f1088fa8be6938715f662494e75fdd7cd4ef/blasthttp-0.9.0-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:ea9199cb2f1e6460b73b0ef5d99d7aa4614789d2c8fcb0f2662c49a69cc7fc12", size = 4663884, upload-time = "2026-06-15T21:35:57.559Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/246652873eece7a4ac1e8197814a1411f4f22b8512b19dde727032282d4c/blasthttp-0.9.0-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:147129f105fafc7940d16c2cb776f263e26da808fdb46357522757c02972747d", size = 4281239, upload-time = "2026-06-15T21:36:04.76Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6f/63136147f360833e4dfd0b2c2a1e3697643726319d1f7dced6cec5e3c30a/blasthttp-0.9.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae6a2790fff9b448b611ae3c5f46275ba90bdbf6ade4722f3986b491063ac37c", size = 4420274, upload-time = "2026-06-15T21:36:20.931Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/10/8483c4cef830d81032f4c90d72cc0c215050b2f0456f8adc5391a4b1a321/blasthttp-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7035bef149beea7074c1653afa2ae7f679f80afb53540ad2bf5aca8ba03c89b9", size = 5052232, upload-time = "2026-06-15T21:36:28.491Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fa/f726362b5b1a890920e33940ef99f5eb1808689f848c33c6a27d7fdd7c10/blasthttp-0.9.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:174b6f4e380324dbb724f87348715752c852c68735b55c2a01dec9809cc13241", size = 4376916, upload-time = "2026-06-15T21:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/74/9c608c6d83fe9acb0273b31b3e0346d63d2915585d90c5345313c5cfb2ac/blasthttp-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:d9595e79d60c924f0af7ff54fddf9fddbae6876cba09b5f3975d26f77c84e40d", size = 4800238, upload-time = "2026-06-15T21:36:43.535Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/8fa9c49735bec973ddd5ed0da3651f8c5b21bc5919efb123219e46b7eaa5/blasthttp-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:065f71b3a83e934c732e61379224e3101030396409d1224fe133e3d3da25705b", size = 4764591, upload-time = "2026-06-15T21:36:51.504Z" },
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.0" },
-    { name = "bbot", git = "https://github.com/blacklanternsecurity/bbot?rev=404bbbc2eaa5b6187580f4d9cd301da7a814aac7" },
+    { name = "bbot", git = "https://github.com/blacklanternsecurity/bbot?rev=69ec06adef33fa5c3d4cdee2c8d370ac892cceb0" },
     { name = "cryptography", specifier = ">=49.0.0" },
     { name = "dnspython", specifier = ">=2.8.0" },
     { name = "fastapi" },
@@ -427,31 +427,33 @@ wheels = [
 
 [[package]]
 name = "cloudcheck"
-version = "10.0.1"
+version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/86/acb3aa69dc96c4a26fe92824430a2eef059ff52157c673094bdbf722c1c6/cloudcheck-10.0.1.tar.gz", hash = "sha256:bb630bc310b5618593e337d33f3ce92e8529e9611dd59fac2644ae7974672a14", size = 4708651, upload-time = "2026-05-05T15:56:44.525Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a7/ef40cc541c87615091321ac67042ce481e32215d93c37fd184fd999d2a0e/cloudcheck-11.1.0.tar.gz", hash = "sha256:6f6d7415fd62dd1dffeb171f603e4f25f451a856924f0b0e7d14851a2b888574", size = 4912429, upload-time = "2026-06-24T01:38:19.915Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/5e/e4d9c8bcce2de9b55fc78a499963137e3ca76a2cd7a77b22255787bd9286/cloudcheck-10.0.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a48f384223e4d09e2ffcb685c67276bf6b3631caaea2c432f2b741f1d90f52dc", size = 1627451, upload-time = "2026-05-05T16:12:49.128Z" },
-    { url = "https://files.pythonhosted.org/packages/be/72/cc261bb0b1b25ae9e10cdd6d4b086e4f81620feb5f9dbb563e8bd5af3218/cloudcheck-10.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1aa1896424ec0ff5642a351378d85709607aa7886fb00660186dc2aff1e3e1b7", size = 1600090, upload-time = "2026-05-05T16:12:41.682Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/53/524a8404ce97123aa4eedfbdbf86edebf638594c751796a531e1aaacd1d0/cloudcheck-10.0.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77915c4628f6a0565013c45abc2674c3ab1f0b0e547bbd120f839baed4f226c3", size = 4225346, upload-time = "2026-05-05T16:11:24.86Z" },
-    { url = "https://files.pythonhosted.org/packages/01/ee/bb8ff9934fd7fe1b0c72d4b4d5f435e91805fa7577250ad0703cfadd5a11/cloudcheck-10.0.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:67d63d673d8ab54c6a9f873aefa4f0285d59d3eac8f9cb5b1c9f864ef4d68259", size = 3581459, upload-time = "2026-05-05T16:11:42.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/d7/4029843c588198bec610e901b56bc7e35650bfa29d58d1f202a90706dfc6/cloudcheck-10.0.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6c688f16586d13d522640b21e3b39b83450dbc3c80310933ea3c21412cc871b9", size = 4164626, upload-time = "2026-05-05T16:12:16.007Z" },
-    { url = "https://files.pythonhosted.org/packages/63/2f/28f18b54329d042580b97b165b7baa6c2ed4a1f8cc82e5dd95b260575894/cloudcheck-10.0.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e493595ccffdcd11e21d05e299a0ede6c383ac3fd106d7d93b3ea2be0bb8933f", size = 4074681, upload-time = "2026-05-05T16:12:00.009Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/a2/7852f03d6f609ee142fe889e68ab265d80ff42ce2b82a8d4554ec9905d4b/cloudcheck-10.0.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:767d321bdc8e7c36f38ca2e1fa9ce7b8b868fc8a9957c4e9d268af1b89548f2b", size = 4018481, upload-time = "2026-05-05T16:12:29.976Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/09/459243f30e83689e0eb284b9761ac658fa97713f880297d542f1d9e0007c/cloudcheck-10.0.1-cp314-cp314-manylinux_2_38_x86_64.whl", hash = "sha256:7f3076e79f3e5b5f39dd2782f81fdc917a3c3d589c4d9941db0a7f68614717b8", size = 3578885, upload-time = "2026-05-05T15:56:42.322Z" },
-    { url = "https://files.pythonhosted.org/packages/46/e8/83c96b9e68369efd57c049728e7088ee9502101e377f305e090cc7618e17/cloudcheck-10.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2cffd1a339646e5fdd9bc7cbc27b90c6cd376747a5e76d7e76bfdc51ef27a3e6", size = 4626473, upload-time = "2026-05-05T16:13:00.951Z" },
-    { url = "https://files.pythonhosted.org/packages/48/39/a0a00ecc3f4c7ad595ff7d822fc86136e1a1730053df71647daa833214f4/cloudcheck-10.0.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:131d44336ad344b770b585167cd8441ca6dad56142f5b278f121c7507621b6bb", size = 3911086, upload-time = "2026-05-05T16:13:19.416Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/9e/95d5c0fdb5592c06ba48c2c2190ccb8e589e1179feeae27e1942e0891457/cloudcheck-10.0.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:af756db3fba6215bf6b1919f230d8955a8f559e3d40a5144a867e6255695b396", size = 4255885, upload-time = "2026-05-05T16:13:39.794Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/d8/458ab1c4f025d7e66bed589f75b92dc6ee730cc58c820c56198d57886937/cloudcheck-10.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f2c52183a93d6ad5982c9f9e62e3a29529ba99db1c3414f4ca536971cd69146f", size = 4282302, upload-time = "2026-05-05T16:13:58.767Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/42/c9d42202482cb225d40cb58f5eb0759b506098cb98f0effb3e08dd4dd843/cloudcheck-10.0.1-cp314-cp314-win32.whl", hash = "sha256:646a8ca0e5baf4f3529835a84f44897988da653d241ad0cc79dfe1121e2e75af", size = 1318837, upload-time = "2026-05-05T16:14:16.138Z" },
-    { url = "https://files.pythonhosted.org/packages/77/c5/a3e31beca7adf72ff5bad3e50c4c1c55d50fba951012b5b3e88d6a3fc038/cloudcheck-10.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:c13b291694055df8f9dfd191a8ae28c9c0dc0c59fa7e2405b3fbd33d8374d6d7", size = 1411970, upload-time = "2026-05-05T16:14:14.37Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/d8/4be803b52c88926a62639edb17ef7f92f4033a3815b0e9f8c3bda26dccca/cloudcheck-10.0.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bf8904c171540307013302e3c23fee30545eda3c66ee8af9355d64a701aad66", size = 4225821, upload-time = "2026-05-05T16:11:26.655Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/46/4de7c8abf39980aa60b5dd2dbfc76c91a33bcf7131207ff32be8d3089c75/cloudcheck-10.0.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1e8de3b38fed4fd188c5cd923908f79ea466e57ec1a0e55e2f620f0101846e47", size = 3582744, upload-time = "2026-05-05T16:11:44.451Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/9a/be6fca0b37afac0eef1474e0bece7d36b3eea5964f76f5596534134682c1/cloudcheck-10.0.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11cd4996cc5a8d812f5139b8ccce656fef41d9c2b1b24b8b823501cd82927ec4", size = 4074240, upload-time = "2026-05-05T16:12:02.06Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/04/1d579da2dac3af994fa406b6a019331fb3d3618fb6dfba794395840b0afb/cloudcheck-10.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7c1daddd0c34614bdd438947688d83b4d862728f422ffb8700eb37d7fbee3e7c", size = 4626868, upload-time = "2026-05-05T16:13:03.211Z" },
-    { url = "https://files.pythonhosted.org/packages/54/1f/4da23681a3e2c49681c9492633388e94d3b97062cf053fd2cd8b2a655601/cloudcheck-10.0.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a35476e0da6e6c442a750e8a207b9729ee8a260038a7eb378d535a4a8434c2e7", size = 3912371, upload-time = "2026-05-05T16:13:21.252Z" },
-    { url = "https://files.pythonhosted.org/packages/12/2a/a9fef94625dea4b31a045e0f2b51efae3b23d61241e85d71bccc839851c2/cloudcheck-10.0.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:1958083f007636dedf68a2d00c707c607864d09765a30ad01b237f479523cdd0", size = 4256747, upload-time = "2026-05-05T16:13:41.747Z" },
-    { url = "https://files.pythonhosted.org/packages/47/01/19ff1de739db05ff15b007a8a4cef3116174042b336e8b559d7fa92cd29a/cloudcheck-10.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1e60bd640b777ea988fb9ed17bce8056e34d5d24f881b89f0bc22b6d9879c33d", size = 4287043, upload-time = "2026-05-05T16:14:00.775Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e4/ae62a65601098faf2b0b841e7ce5e87617f5c640c8c775087a77dea0b4a4/cloudcheck-11.1.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:37c7b25eebde0bdfadbe23a285ee0570cc6b91aee01400b3d2a12eb9c354e9a6", size = 1628902, upload-time = "2026-06-24T01:52:27.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c8/b57b9930dc5352696f8ce154fcd8c4a1c0e56a7436186430d016c6be0773/cloudcheck-11.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e69c64d371cef736ce7404dbc0d2d4f0af2c645e467432d5596f01f2b3f1c67e", size = 1603546, upload-time = "2026-06-24T01:52:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1d/13e34739ea4b1d6adc4af45c569446f70435616a81facc2b8adc7c3a0e36/cloudcheck-11.1.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5e99315d0e1214987bc2f6463dbfc5864e30a757c0f5a61ab3f569eeab65d804", size = 4227647, upload-time = "2026-06-24T01:51:18.708Z" },
+    { url = "https://files.pythonhosted.org/packages/88/91/f4bb1a4ad1388375d62866c3dbb2d7868d01cc84d529404fecd1ea364ec3/cloudcheck-11.1.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac124c734c5e9e773f55245878819d793eb30662974f67fadf9bfb01e89f5850", size = 3582647, upload-time = "2026-06-24T01:51:31.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/61/36bedf0b70f3a31a25c72c1167a7972652084a7e07c8419fa363f03aab41/cloudcheck-11.1.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14da5f7208fa6248ce96e620eca7888977905ff29de217c294976f098928e255", size = 4166298, upload-time = "2026-06-24T01:51:56.768Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/df/87ddfc882f32b2cfcbbd30b8758cadced445114c17b6979b60ed0d8c7e9f/cloudcheck-11.1.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05cdffad94d306ed391399848c583f917fb4ac25d99e6edddcaa77a9b78a9d5a", size = 4078109, upload-time = "2026-06-24T01:51:44.128Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6d/709c0fb41c52029da2a91df2f2184a37beb8ab95c3c614df2575060b4033/cloudcheck-11.1.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:593f78d4740b83f43955883b24fdc785193b7ff4e679f5545f9e9e6501ea86b5", size = 4019438, upload-time = "2026-06-24T01:52:09.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7b/408820addf925533973abb1da009f8719c4063e4964ade075dcdf50c67d8/cloudcheck-11.1.0-cp314-cp314-manylinux_2_38_x86_64.whl", hash = "sha256:127ffee71e9de652e88c9e0179c59318eedd139b13453e839f0eb7f33e19b88f", size = 3620324, upload-time = "2026-06-24T01:38:18.03Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/47e64da6a7775e8b79c0974ecb05d46c4576ea13c1b61616ee4536d04bc5/cloudcheck-11.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7625d40295f3285d8c81f527ea248e4a4c03a5ae9b0e3be777b7d5b519fffa51", size = 4627588, upload-time = "2026-06-24T01:52:36.667Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/7b3cfa2f917fb529f1b726cfe495258b05b7c689abf815c6786da63f03ad/cloudcheck-11.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:f5cf04e8a36eadcfe66739804df961f570dbacdade908fc8dde856bc7f3a070c", size = 3912050, upload-time = "2026-06-24T01:52:50.423Z" },
+    { url = "https://files.pythonhosted.org/packages/77/43/1e680cbc70bfc2afd40753a2c3458f4568d14a3d605e72871f2aea3f5566/cloudcheck-11.1.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3f4f92835fcf428f4acdc3681739a306c7172b6a7963ef4b272eefd0f390c387", size = 4256341, upload-time = "2026-06-24T01:53:03.479Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/3611ac35cb38a82d0ebbcf3568eefb19ba89b5d93040179a9bf13e93b4bc/cloudcheck-11.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3e38eaf5fa3f871b2afe1caa4c1cf2626af8a55faf7db0f05abeb8895a40ece5", size = 4283526, upload-time = "2026-06-24T01:53:17.642Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/de/6ba44d3ea3c5ed7c03c744ee8155019845975208dc15a00213895fde5923/cloudcheck-11.1.0-cp314-cp314-win32.whl", hash = "sha256:5d418ad7ccd53f1367b31ead8c96c42c324f6eaef8a69f9a82772b5ce651465c", size = 1320213, upload-time = "2026-06-24T01:53:31.805Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/76ad9c8e15524c115b1f11e5b56b4291e0925cb8626989d7d93a503f7a22/cloudcheck-11.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:76a90ae769b9837bf7f5cd7d7831ca3fae36fea839b5fcdd41e7ed8327c05183", size = 1411520, upload-time = "2026-06-24T01:53:30.269Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7a/c414832db140aceb8d7021f787d9fc91f2358cbbb1733c689e939657238a/cloudcheck-11.1.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:416bbc5bcc2da6b77a7c5d83715da8b68ed140ce5435f40ebae7ac8a1669b54e", size = 4230623, upload-time = "2026-06-24T01:51:20.703Z" },
+    { url = "https://files.pythonhosted.org/packages/08/5a/6062da2e386424f35907ffe5f9fa5f8d76efa9ba7b297f17ff6e2bfcfd7b/cloudcheck-11.1.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75c04c26554d8b98564a6a354b7b5a23769fe106b81f6fe6bcf54d3f482f0937", size = 3579147, upload-time = "2026-06-24T01:51:33.376Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9b/ba7c8bb8243c4a5ce4cc2522f046bd71742b0423738eb945cc778659d486/cloudcheck-11.1.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:af81fdf60c2369b384c182017c188bcbe6fd7a7a9dfb504f4e52ebd09f9dcd46", size = 4164579, upload-time = "2026-06-24T01:51:58.599Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/cf/0d81beba95d8ff0c64e9604f4abaf7001dc536f48efb54ab2b92c7a3539b/cloudcheck-11.1.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d619c5beef80b831a95508dca6e7400378295a81f593290490f1e919b2d3ba4", size = 4078924, upload-time = "2026-06-24T01:51:45.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d0/050ab1722d6c1a628ab6c2e5a1ba6788f79a14c16e1ea959467736a6d4bc/cloudcheck-11.1.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6914ec7776c85b73a739e2e6708fa7e730d28ab15010f4fba401386beee50180", size = 4025140, upload-time = "2026-06-24T01:52:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/35/97/2bb5e69c7aded98bc9efc5cec1d648d9e5e4b4c3a717103f4d8513a66a5f/cloudcheck-11.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74542a999b0b633c43a68ed6e51ccc4a1f1c7e5b009d774d29c9a3d2164742af", size = 4631093, upload-time = "2026-06-24T01:52:38.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/37/f7559e749951eb2b639eee322018c276bd1b4eb892ae7d46514b2afa4c63/cloudcheck-11.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8cd31034b0be3b3bf706543e54eb61b4c31567484554f3c44b490f0759302e2b", size = 3909734, upload-time = "2026-06-24T01:52:52.269Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/34/c22c7b6863d9302b2cd94887dbea46a9d69be5d5ccb8f37459d9eb637028/cloudcheck-11.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:bf2cc009afa271b2ebfde51364003d67fe439d0a6c4c2740ceeb25ef0c36ad8b", size = 4253930, upload-time = "2026-06-24T01:53:05.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/88/a26706ee3c86e0d2b990d3184d38a7b69dc2fc2bd11b45dda4325cc9f9cf/cloudcheck-11.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:de8b44c02d05d5a5c4629b88f3edfadcefee2834b90a8b8888b4d56e2b8b1922", size = 4290138, upload-time = "2026-06-24T01:53:19.41Z" },
 ]
 
 [[package]]
@@ -536,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -545,9 +547,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -955,11 +957,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -1403,11 +1405,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -1454,7 +1456,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.29.0"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -1462,13 +1464,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/95/22e2e19ad95d42d69320e8cd8d48c8543841f367d2d5a4dca48165e466d2/temporalio-1.29.0.tar.gz", hash = "sha256:3fbfddc5f847956ca20c2e671d3f09cefdb2ab6f0d6a6d59664c6102e922f80b", size = 2657001, upload-time = "2026-06-17T21:18:16.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/b0/ad8fc3cd7425c6551a637bf23c798e8fdd8eb7a3ec4fee4f46f7678ba8d2/temporalio-1.30.0.tar.gz", hash = "sha256:7c025919511bb465392d547e48ccb85fd560a995db4ebcc82fdb43cddf088e6f", size = 2686876, upload-time = "2026-07-02T21:04:46.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/82/e0810e7e7f5f4eb97e40468abf6bc8d3df0dbc882c09a2c207c38c90d56d/temporalio-1.29.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9d18f989fbea13014e3221de034fbd1945ec05499b663195f0eacb49cc922986", size = 14874156, upload-time = "2026-06-17T21:18:03.299Z" },
-    { url = "https://files.pythonhosted.org/packages/41/48/55a2f948f4cd30d8dcaf1d37a15e23b34d90a68d0d1da6765a08c650bbb2/temporalio-1.29.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:28bc12b64a7ffc08f7709897d3a0c93faa8972227734669f248cb7de2ce3e69f", size = 14384773, upload-time = "2026-06-17T21:18:06.151Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/71/a13f427089b54de4e11f347b2043934d693baffda569c4b4914e588a6074/temporalio-1.29.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd02a107c3f5fa088ed5e4aeda9af91d11afbc53dfd5b28d730776354b159297", size = 14602055, upload-time = "2026-06-17T21:18:08.704Z" },
-    { url = "https://files.pythonhosted.org/packages/73/6a/3ee32775c9b5172560add2ec69c554f476bc6c51ea7a3c24206e03f08cc5/temporalio-1.29.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:950b42e05793762eb7b4b3809e78c9e9dcdf2f23f797aa939ac17eca8ad9b3d3", size = 15075878, upload-time = "2026-06-17T21:18:11.499Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/92/24ef16052075a08e7ed071311704a244944485bc8581d82313f0c3d1b385/temporalio-1.29.0-cp310-abi3-win_amd64.whl", hash = "sha256:8969718f947c6b9df3b51ab4a71bad67abfce81a1023aa1a598a224b712b713a", size = 15333733, upload-time = "2026-06-17T21:18:14.201Z" },
+    { url = "https://files.pythonhosted.org/packages/02/39/842fdffe93388dd30ac12a53a698f71cbfb68b3bc938f30f3e5d6a36d4ad/temporalio-1.30.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6773a6b708dee7675fcbb681bf28e48337ce43b8467ceba8f903e78ae68909f8", size = 14520026, upload-time = "2026-07-02T21:04:31.384Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f3/a2237d5265eb29de591abeac7610a48616b590a1b923b4919f60ee81adfa/temporalio-1.30.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4038c3ce2d9acc12fef31dd16ef9be8cc7f721672da5662aa05e3942d0b5c9d1", size = 14018523, upload-time = "2026-07-02T21:04:34.405Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/57/dc648d812f4c688bd246a616f0d65c5f03b33675df2effb1b480e1df6d21/temporalio-1.30.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:108d1a56e174eabc18add58316084cdead230e239d3df22bbe999d6954986591", size = 14330502, upload-time = "2026-07-02T21:04:37.39Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e1/dbd57de0f5090891850c2ee5490319834a12b704076b11f32a4a149998d4/temporalio-1.30.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47b156138de30c2cd6723d5bfc06a30abcf680344c5481abb31f2a98a9b1f809", size = 14833364, upload-time = "2026-07-02T21:04:40.454Z" },
+    { url = "https://files.pythonhosted.org/packages/30/2a/6d41289c11465ba276a8b417f31d2e469f0fe4b8afacd61d5244151c5fce/temporalio-1.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:3adee28d5ec47bd6309a5eeef7b00126373f119bc5c1b058a34de098542f4da7", size = 15181893, upload-time = "2026-07-02T21:04:43.609Z" },
 ]
 
 [[package]]

--- a/temporal-server/Dockerfile
+++ b/temporal-server/Dockerfile
@@ -1,5 +1,5 @@
 # Check: https://github.com/temporalio/temporal/releases
-ARG TEMPORAL_VERSION=1.31.1
+ARG TEMPORAL_VERSION=1.31.2
 ARG TEMPORAL_CLI=1.7.2
 
 # SQL schema migrations source (temporal-sql-tool at startup)

--- a/temporal-ui/Dockerfile
+++ b/temporal-ui/Dockerfile
@@ -1,5 +1,5 @@
 # Check: https://github.com/temporalio/ui/releases
-FROM temporalio/ui:2.51.1
+FROM temporalio/ui:2.52.0
 
 LABEL \
     name="CISO360AI Temporal UI" \

--- a/zitadel/Dockerfile
+++ b/zitadel/Dockerfile
@@ -1,7 +1,7 @@
 # Custom Zitadel image with AWS RDS SSL support
 
 # Check: https://github.com/zitadel/zitadel/releases and use -debug variant for shell access
-FROM ghcr.io/zitadel/zitadel:v4.15.3-debug
+FROM ghcr.io/zitadel/zitadel:v4.16.0-debug
 
 LABEL \
     name="CISO360AI ZITADEL" \


### PR DESCRIPTION
## Summary

Routine dependency + base-image bumps:

- **temporal-server** — Temporal `1.31.1 → 1.31.2`.
- **temporal-ui** — base `temporalio/ui 2.51.1 → 2.52.0`.
- **zitadel** — base `zitadel v4.15.3-debug → v4.16.0-debug`.
- **bbot** — re-pin upstream `dev` HEAD (`404bbbc2 → 69ec06ad`), `nuclei 3.9.0 → 3.11.0`, drop `wpscan` module; Python `fastapi 0.136.3 → 0.139.0`, `temporalio 1.29.0 → 1.30.0`, `pip 26.1 → 26.1.2`, `soupsieve 2.8.3 → 2.8.4`.
- **backend-base** — `fastapi 0.136.3 → 0.139.0`, `temporalio 1.29.0 → 1.30.0` (aligns with the app repo).

## Test plan

- [x] `uv lock --check` in `backend-base/` and `bbot/` — lockfiles in sync.
- [x] `docker buildx build` — all five images build (Python images verify `uv sync --frozen`).
